### PR TITLE
Cast before compare to avoid a compiler warning.

### DIFF
--- a/src/aomodule.c
+++ b/src/aomodule.c
@@ -26,7 +26,7 @@ uint_32_obj (PyObject *obj, void *addr) {
 
   value = PyLong_AsUnsignedLong(obj);
 
-  if (value != -1 || !PyErr_Occurred()) {
+  if (value != (unsigned long)-1 || !PyErr_Occurred()) {
     if (value <= 0xffffffff) {
       *value_32 = (uint_32) value;
       return 1;


### PR DESCRIPTION
The raw comparison flags a warning that we're comparing a signed int with an unsigned int.  The Python programming manual indicates we should expect the possible error code to be (unsigned int)-1, so let's cast the constant and the warning disappears.