### PR TITLE
use memcpy instead of Py_MEMCPY (see <http://bugs.python.org/issue28126>)

### DIFF
--- a/src/aomodule.c
+++ b/src/aomodule.c
@@ -381,7 +381,7 @@ py_ao_play(ao_Object *self, PyObject *args)
     return PyErr_NoMemory();
 
   Py_BEGIN_ALLOW_THREADS
-  Py_MEMCPY(output_samples, samples, sizeof(char) * num_bytes);
+  memcpy(output_samples, samples, sizeof(char) * num_bytes);
   ao_play(self->dev, output_samples, num_bytes);
   Py_END_ALLOW_THREADS
 


### PR DESCRIPTION
it seems Py_MEMCPY was only ever a workaround for a performance limitation in Windows. It is now deprecated, so replace it with the more usual memcpy call.

Patch provided by @ldo in #1 

Fixes #1.