### PR TITLE
Set `PY_SSIZE_T_CLEAN` so that `y#` works with Python 3.11.

### DIFF
--- a/src/aomodule.c
+++ b/src/aomodule.c
@@ -364,11 +364,12 @@ py_ao_play(ao_Object *self, PyObject *args)
   const char *samples;
   char *output_samples;
   uint_32 num_bytes = 0;
-  int len;
 
 #if PY_MAJOR_VERSION >= 3
+  Py_ssize_t len;
   if (!(PyArg_ParseTuple(args, "y#|O&", &samples, &len, uint_32_obj, &num_bytes)))
 #else
+  int len;
   if (!(PyArg_ParseTuple(args, "s#|O&", &samples, &len, uint_32_obj, &num_bytes)))
 #endif
     return NULL;

--- a/src/aomodule.h
+++ b/src/aomodule.h
@@ -19,6 +19,8 @@
 #ifndef __AO_MODULE_H__
 #define __AO_MODULE_H__
 
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <structmember.h>
 #include <ao/ao.h>


### PR DESCRIPTION
Per https://docs.python.org/3/c-api/arg.html#strings-and-buffers we no longer fall back to `int` type for the buffer size.

Fixes #8 